### PR TITLE
Add currency for transaction

### DIFF
--- a/model/model_transaction.go
+++ b/model/model_transaction.go
@@ -26,6 +26,8 @@ type Transaction struct {
 	// Transaction amount
 	Amount float64 `json:"amount"`
 	// Transaction purpose. Maximum length: 2000
+	Currency string `json:"currency,omitempty"`
+	// Transaction currency in ISO 4217 format.This field can be null if not explicitly provided the bank. In this case it can be assumed as account’s currency.
 	Purpose string `json:"purpose,omitempty"`
 	// Counterpart name. Maximum length: 80
 	CounterpartName string `json:"counterpartName,omitempty"`

--- a/model/model_transaction.go
+++ b/model/model_transaction.go
@@ -27,7 +27,7 @@ type Transaction struct {
 	Amount float64 `json:"amount"`
 	// Transaction purpose. Maximum length: 2000
 	Currency string `json:"currency,omitempty"`
-	// Transaction currency in ISO 4217 format.This field can be null if not explicitly provided the bank. In this case it can be assumed as account’s currency.
+	// Transaction currency in ISO 4217 format. This field can be null if not explicitly provided the bank. In this case it can be assumed as account’s currency.
 	Purpose string `json:"purpose,omitempty"`
 	// Counterpart name. Maximum length: 80
 	CounterpartName string `json:"counterpartName,omitempty"`


### PR DESCRIPTION
In version 1.25.0 of the API a currency field was added to the transaction object.

Added this manually for now without regenerating the client because there is a new generator that creates different code now which will require some more work to get ready and test.